### PR TITLE
fix(deps): Upgrade intl to version 0.19.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  intl: ^0.18.0
+  intl: ^0.19.0
   json_annotation: ^4.5.0
   meta: ^1.7.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   json_serializable: ^6.2.0
-  lints: ^2.0.1
-  mockito: 5.4.0
-  test: ^1.21.1
+  lints: ^5.1.1
+  mockito: ^5.4.5
+  test: ^1.25.0


### PR DESCRIPTION
Renovate wanted to upgrade it to 0.20.0 in #11 , but that equally breaks Flutter applications, because even the latest Flutter (3.27.1) at this moment has intl pinned to version 0.19.0.

Also because the test dependency was too old for latest Dart versions, strange errors show up. So I had to do some other peasant upgrades along the way. 